### PR TITLE
  **Fix:** Fix negative margin issue

### DIFF
--- a/src/AvatarGroup/AvatarGroup.tsx
+++ b/src/AvatarGroup/AvatarGroup.tsx
@@ -22,6 +22,7 @@ export interface AvatarGroupProps extends DefaultProps {
 
 const Container = styled("div")({
   display: "flex",
+  marginLeft: 12,
 })
 
 const GroupedAvatar = styled(Avatar)({


### PR DESCRIPTION
Add Negative margin only after first child

# Summary

Fixing negative margin problem that was breaking the AvatarGroup composition in the box model

Problem:

![Screen Shot 2019-06-24 at 1 07 01 PM](https://user-images.githubusercontent.com/32997409/60000023-00360a80-9681-11e9-993c-484aea5ad653.png)

Solution:

![Screen Shot 2019-06-24 at 1 07 47 PM](https://user-images.githubusercontent.com/32997409/60000089-1fcd3300-9681-11e9-9e30-a6e9dd077407.png)

# Related issue

AvatarGroup negative margin breaks design #1076

# To be tested

Me
- [x] No error or warning in the console on `localhost:6060`


Tester 1

- [ ] Things look good on the demo.
  

Tester 2

- [ ] Things look good on the demo.
  
